### PR TITLE
Create branch with Java 17

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
     - name: Grant execute permission for gradlew
       shell: bash
       run: chmod +x gradlew


### PR DESCRIPTION
It is not mandatory to merge into `main` branch. For GrowthBook Kotlin SDK it will be enough if this will be merged into another branch for example `java17`